### PR TITLE
Change 'settings' object validation check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@
         inputErrorBorder = '2px solid red';
 
     var FormValidator = function (form, settings) {
-        if (!form || (settings && typeof settings !== 'object')) {
+        if (!form || !settings || typeof settings !== 'object') {
             return;
         }
 


### PR DESCRIPTION
#4 

The following used code :
```
settings && typeof settings !== 'object'
``` 
Is equivalent to : 
```
Boolean(settings) && typeof settings !== 'object'
```
and because Boolean(null) is a **falsy** value the null check will never be caught.