### PR TITLE
Improve object validations check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,9 +89,9 @@
         }
 
         this.form = form instanceof Element ? form : document.querySelector(form);
-        this.events = (settings && settings.events && this.initEvents(settings.events)) || defaultEvents;
-        this.showErrors = typeof (settings && settings.showErrors) === 'undefined' ? showErrors : settings.showErrors;
-        this.lang = (settings && settings.lang) || defaultLang;
+        this.events = (settings.events && this.initEvents(settings.events)) || defaultEvents;
+        this.showErrors = settings.showErrors || showErrors;
+        this.lang = settings.lang || defaultLang;
         this.constraints = {};
         this.errors = {};
 


### PR DESCRIPTION
#4 
- Remove redundant 'settings' object validation check.
- Replace the checking mechanism for 'undefined' values with simplified coercion expressions which gives even wider checking area as it checks for all the **falsy** values e.g undefined, null and 0