### PR TITLE
Objects validation check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@
         inputErrorBorder = '2px solid red';
 
     var FormValidator = function (form, settings) {
-        if (!form || (settings && typeof settings !== 'object')) {
+        if (!form || !settings || typeof settings !== 'object') {
             return;
         }
 
@@ -89,13 +89,13 @@
         }
 
         this.form = form instanceof Element ? form : document.querySelector(form);
-        this.events = (settings && settings.events && this.initEvents(settings.events)) || defaultEvents;
-        this.showErrors = typeof (settings && settings.showErrors) === 'undefined' ? showErrors : settings.showErrors;
-        this.lang = (settings && settings.lang) || defaultLang;
+        this.events = (settings.events && this.initEvents(settings.events)) || defaultEvents;
+        this.showErrors = settings.showErrors || showErrors;
+        this.lang = settings.lang || defaultLang;
         this.constraints = {};
         this.errors = {};
 
-        if (settings) {
+        if (settings.constraints) {
             this.buildConstraints(settings.constraints);
             typeof settings.submitHandler === 'function' && (this.submitHandler = settings.submitHandler);
             typeof settings.invalidHandler === 'function' && (this.invalidHandler = settings.invalidHandler);


### PR DESCRIPTION
#4
**Fixed bugs :**
* Remove redundant 'settings' object validation check.
* Replace the checking mechanism for 'undefined' values with simplified coercion expressions which gives even wider checking scope as it checks for all the **falsy** values e.g undefined, null and 0.

**Further explanation about why null is never going to be caught :**

The following used code :
```
settings && typeof settings !== 'object'
```
Is equivalent to :
```
Boolean(settings) && typeof settings !== 'object'
```
Because Boolean(null) is a **falsy** value the null check will never be caught.
